### PR TITLE
Update README.md w/o legacy build_vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # SmaRP 1.1.1-9000
 
 * launch_application() exposes the launch.browser argument to shiny::runApp (#108).
+* Updated install_github() README instructions due to un-supported build_vignettes argument (#120).
 
 # SmaRP 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ containers](https://www.docker.com/resources/what-container)) and can be
 accessed at https://mirai-solutions.ch/apps/smarp/.
 
 The (development version of) **SmaRP** can also be served locally by installing the package from GitHub
+<!-- argument build_vignettes not available anymore (r-lib/remotes#353), build_opts = "" for a full installation including vignettes  -->
 ``` r
-devtools::install_github("miraisolutions/SmaRP", build_vignettes = TRUE)
+devtools::install_github("miraisolutions/SmaRP", build_opts = "")
 ```
 and running
 ``` r


### PR DESCRIPTION
Argument `build_vignettes` not available anymore in `devtools`, now based on `remotes` (see r-lib/remotes#353). Instead `build_opts = ""` can be used for a full installation including vignettes.