### PR TITLE
remove emails of people that left Mirai

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,9 +4,9 @@ Version: 1.3.0-9000
 Authors@R: c(person("Gabriel", "Foix", role = c("aut")),
              person("Francesca", "Vitalini", role = c("aut")),
              person("Nicoletta", "Farabullini", role = c("aut")),
-             person("Riccardo", "Porreca", role = c("ctb", "cre"),
+             person("Riccardo", "Porreca", role = c("aut", "cre"),
                     email = "riccardo.porreca@mirai-solutions.com"),
-             person("Mirai Solutions GmbH", role = c("ctb", "cph"),
+             person("Mirai Solutions GmbH", role = "cph",
                     email = "info@mirai-solutions.com"))
 Description: Shiny App to calculate total pension fund.
 Depends: R (>= 3.5.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 1.3.0-9000
 Authors@R: c(person("Gabriel", "Foix", role = c("aut")),
              person("Francesca", "Vitalini", role = c("aut")),
              person("Nicoletta", "Farabullini", role = c("aut")),
-             person("Riccardo", "Porreca", role = c("ctb"),
+             person("Riccardo", "Porreca", role = c("ctb", "cre"),
                     email = "riccardo.porreca@mirai-solutions.com"),
              person("Mirai Solutions GmbH", role = c("ctb", "cph"),
                     email = "info@mirai-solutions.com"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,9 @@
 Package: SmaRP
 Title: SmaRP: Smart Retirement Planning
 Version: 1.3.0-9000
-Authors@R: c(person("Gabriel", "Foix", role = c("aut", "cre"),
-                    email = "gabriel.foix@mirai-solutions.com"),
-             person("Francesca", "Vitalini", role = c("aut"),
-                    email = "francesca.vitalini@mirai-solutions.com"),
-             person("Nicoletta", "Farabullini", role = c("aut"),
-                    email = "nicoletta.farabullini@mirai-solutions.com"),
+Authors@R: c(person("Gabriel", "Foix", role = c("aut")),
+             person("Francesca", "Vitalini", role = c("aut")),
+             person("Nicoletta", "Farabullini", role = c("aut")),
              person("Riccardo", "Porreca", role = c("ctb"),
                     email = "riccardo.porreca@mirai-solutions.com"),
              person("Mirai Solutions GmbH", role = c("ctb", "cph"),


### PR DESCRIPTION
Do not merge before February.

We still need to define a new person to receive the "cre" role. Should we just add @riccardoporreca as the only person left with an email or someone else? What do you think @RolandASc ?

Another open point is how to bring this to master: I don't think it makes sense to create a new release for this, but we need to update the DESCRIPTION file there as well eventually. Someone with admin access could also change the default branch to "develop", which would anyway be the expectation for the GitFlow approach.