### PR TITLE
Revise README local installation / run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,24 @@ The **SmaRP** Shiny app is [deployed](gke#readme) to Google Cloud Platform
 (using [Docker containers](https://www.docker.com/resources/what-container)) and
 can be accessed at https://mirai-solutions.ch/gallery/smarp.
 
-The R package **SmaRP** can be installed from GitHub with
+**SmaRP** is developed using a [GitFlow](git-flow#readme) approach, where the `master` branch always reflects the _latest_ [release](https://github.com/miraisolutions/SmaRP/releases) of the live app, whereas branch `develop` collects the latest delivered developments for the _next_ releases.
+
+The R package **SmaRP** for the latest release can be installed from GitHub with
 <!-- argument build_vignettes not available anymore (r-lib/remotes#353), build_opts = "" for a full installation including vignettes  -->
 ``` r
-remotes::install_github("miraisolutions/SmaRP", build_opts = "")
+remotes::install_github("miraisolutions/SmaRP@master", build_opts = "")
 ```
-and used to serve the app locally from R via
+whereas the development version can be installed via
+``` r
+remotes::install_github("miraisolutions/SmaRP@develop", build_opts = "")
+```
+
+Then, the installed package can be used to serve the app locally from R via
 ``` r
 SmaRP::launch_application()
 ```
-**SmaRP** is developed using a [GitFlow](git-flow#readme) approach, hence the `master` branch always reflects the _latest_ [release](https://github.com/miraisolutions/SmaRP/releases) of the live app, whereas branch `develop` collects the latest delivered developments for the _next_ releases, which can be installed locally via
-``` r
-remotes::install_github("miraisolutions/SmaRP", "develop", build_opts = "")
-```
 
-Note that **SmaRP** is deployed using [version-stable](https://github.com/rocker-org/rocker-versioned#readme) images from the [Rocker project](https://www.rocker-project.org/). The target environment of the live app is currently bound to R 3.5.3. Therefore, the app is developed and tested with the corresponding version of R and packages, as opposed to the latest available versions.
+Note that **SmaRP** is deployed using [version-stable](https://github.com/rocker-org/rocker-versioned#readme) images from the [Rocker project](https://www.rocker-project.org/). The target environment of the live app is currently bound to R 3.5.3. Therefore, the app is developed and tested with the corresponding version of R and packages, as opposed to the latest available versions. This is made easy by the containerized approach to align version-stable development and deployment environments described in our [techguides](https://mirai-solutions.ch/techguides/align-local-development-and-deployment-environments.html#align-local-development-and-deployment-environments).
 
 
 ## Details and key features

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then, the installed package can be used to serve the app locally from R via
 SmaRP::launch_application()
 ```
 
-Note that **SmaRP** is deployed using [version-stable](https://github.com/rocker-org/rocker-versioned#readme) images from the [Rocker project](https://www.rocker-project.org/). The target environment of the live app is currently bound to R 3.5.3. Therefore, the app is developed and tested with the corresponding version of R and packages, as opposed to the latest available versions. This is made easy by the containerized approach to align version-stable development and deployment environments described in our [techguides](https://mirai-solutions.ch/techguides/align-local-development-and-deployment-environments.html#align-local-development-and-deployment-environments).
+Note that **SmaRP** is deployed using [version-stable](https://github.com/rocker-org/rocker-versioned#readme) images from the [Rocker project](https://www.rocker-project.org/). The target environment of the live app is currently bound to R 3.5.3. Therefore, the app is developed and tested with the corresponding version of R and packages, as opposed to the latest available versions. This is made easy by the containerized approach to align version-stable development and deployment environments described in our [techguides](https://mirai-solutions.ch/techguides/align-local-development-and-deployment-environments.html).
 
 
 ## Details and key features

--- a/git-flow/README.md
+++ b/git-flow/README.md
@@ -11,7 +11,7 @@ We use a [**GitFlow**](https://nvie.com/posts/a-successful-git-branching-model/)
 The overall GitFlow branching system is described as follows:
 
 - No work is committed and pushed directly to `master`, which is updated only as part of a [**release**](#versioning-and-releases).
-- Only small maintenance work in context of releases can be done directly in `develop` (i.e. only version and `NEWS.md` changes, see also below). Meaningful pieces should be developed in a dedicated **_feature_ branch** created from `develop` and associated to a GitHub issue (`<ID>`).
+- Only small maintenance work, including [release preparation](#versioning-and-releases), can be done directly in `develop`. Meaningful pieces should be developed in a dedicated **_feature_ branch** created from `develop` and associated to a GitHub issue (`<ID>`).
     - By convention, the branch name is of the form `feature/<ID>-short-lowercase-title`. This also applies to bug-fixes, where a separate naming like `fix/<ID>-xyz` should be avoided (see [nvie/gitflow#24](https://github.com/nvie/gitflow/issues/24)), possibly using something like `feature/<ID>-fix-xyz` instead, e.g. `feature/142-fix-p2-interest-rate-step` for [#142](https://github.com/miraisolutions/SmaRP/issues/142). Note however that hot-fixes are treated differently, as explained below.
     - Once completed, the branch is merged back into `develop` via a pull request.
     - Each significant development must be mentioned as a bullet point in the top-section of [**`NEWS.md`**](../NEWS.md) before being pushed to or merged into `develop`, to serve as a change log for the next release.

--- a/git-flow/README.md
+++ b/git-flow/README.md
@@ -6,12 +6,12 @@
 We use a [**GitFlow**](https://nvie.com/posts/a-successful-git-branching-model/) branching model, where the repository holds two main **branches** with an infinite lifetime:
 
 - [**`master`**](https://github.com/miraisolutions/SmaRP/tree/master) reflects the [**latest release**](https://github.com/miraisolutions/SmaRP/releases/latest) to production, i.e. the current version of the [live app](https://mirai-solutions.ch/gallery/smarp).
-- [**`develop`**](https://github.com/miraisolutions/SmaRP/tree/develop) collects all completed developments for the [**next release**](#versioning-and-releases).
+- [**`develop`**](https://github.com/miraisolutions/SmaRP/tree/develop) is set as the default branch and collects all completed developments for the [**next release**](#versioning-and-releases).
 
-The overall GitFlow branching system is described as follows
+The overall GitFlow branching system is described as follows:
 
 - No work is committed and pushed directly to `master`, which is updated only as part of a [**release**](#versioning-and-releases).
-- Small (maintenance) work can be done directly in `develop`, however meaningful pieces should be developed in a dedicated **_feature_ branch** created from `develop` and associated to a GitHub issue (`<ID>`).
+- Only small maintenance work in context of releases can be done directly in `develop` (i.e. only version and `NEWS.md` changes, see also below). Meaningful pieces should be developed in a dedicated **_feature_ branch** created from `develop` and associated to a GitHub issue (`<ID>`).
     - By convention, the branch name is of the form `feature/<ID>-short-lowercase-title`. This also applies to bug-fixes, where a separate naming like `fix/<ID>-xyz` should be avoided (see [nvie/gitflow#24](https://github.com/nvie/gitflow/issues/24)), possibly using something like `feature/<ID>-fix-xyz` instead, e.g. `feature/142-fix-p2-interest-rate-step` for [#142](https://github.com/miraisolutions/SmaRP/issues/142). Note however that hot-fixes are treated differently, as explained below.
     - Once completed, the branch is merged back into `develop` via a pull request.
     - Each significant development must be mentioned as a bullet point in the top-section of [**`NEWS.md`**](../NEWS.md) before being pushed to or merged into `develop`, to serve as a change log for the next release.

--- a/git-flow/README.md
+++ b/git-flow/README.md
@@ -6,7 +6,7 @@
 We use a [**GitFlow**](https://nvie.com/posts/a-successful-git-branching-model/) branching model, where the repository holds two main **branches** with an infinite lifetime:
 
 - [**`master`**](https://github.com/miraisolutions/SmaRP/tree/master) reflects the [**latest release**](https://github.com/miraisolutions/SmaRP/releases/latest) to production, i.e. the current version of the [live app](https://mirai-solutions.ch/gallery/smarp).
-- [**`develop`**](https://github.com/miraisolutions/SmaRP/tree/develop) is set as the default branch and collects all completed developments for the [**next release**](#versioning-and-releases).
+- [**`develop`**](https://github.com/miraisolutions/SmaRP/tree/develop) collects all completed developments for the [**next release**](#versioning-and-releases) and is set as the default branch.
 
 The overall GitFlow branching system is described as follows:
 


### PR DESCRIPTION
~Neither README files currently contradict anywhere the fact that we now switched to "develop" as the default branch. For this PR, I committed some minor refinements that we may want to update the (GitFlow) README with, given that I anyway reviewed it now.~

- Mainly in view of `develop` being the default branch
- Pointer to the techguides for version-stable development environment
- Include also minor refinements that we may want to update the (GitFlow) README
